### PR TITLE
Enforce strict equality in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 # dotenv environment variables file
 .env
 
+
+\.idea/

--- a/test/ack.integration.spec.js
+++ b/test/ack.integration.spec.js
@@ -32,16 +32,16 @@ describe('Acknowledge data in Factom blockchain', function () {
 
     it('should wait on commit ack', async function () {
         const status = await waitOnCommitAck(factomd, 'bbd51be102e7ed19b825acd32d48f1f88033d5b14721f3003f925862b1baf135');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 
     it('should wait on reveal ack', async function () {
         const status = await waitOnRevealAck(factomd, 'ac564d418ffaae59432d644d59fd11f6f0552a1211e9219e16037bc14296c630', '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 
     it('should wait on Factoid transaction ack', async function () {
         const status = await waitOnFactoidTransactionAck(factomd, '09d23680a82f95faafd3562f6b76d83525bdd4575a74656809ced19fa45f72e6');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 });

--- a/test/add.integration.spec.js
+++ b/test/add.integration.spec.js
@@ -24,12 +24,12 @@ describe('Add chains and entries in Factom blockchain', function () {
 
         // Commit
         const committed = await add.commit(factomd, c, PAYING_EC_ADDRESS);
-        assert.equal(committed.txId, computeChainTxId(c).toString('hex'));
+        assert.strictEqual(committed.txId, computeChainTxId(c).toString('hex'));
 
         // Reveal
         const revealed = await add.reveal(factomd, c, PAYING_EC_ADDRESS);
-        assert.equal(revealed.entryHash, c.firstEntry.hashHex());
-        assert.equal(revealed.chainId, c.idHex);
+        assert.strictEqual(revealed.entryHash, c.firstEntry.hashHex());
+        assert.strictEqual(revealed.chainId, c.idHex);
     });
 
     it('should commit and then reveal entry', async function () {
@@ -45,12 +45,12 @@ describe('Add chains and entries in Factom blockchain', function () {
 
         // Commit
         const committed = await add.commit(factomd, e, PAYING_EC_ADDRESS);
-        assert.equal(committed.txId, computeEntryTxId(e).toString('hex'));
+        assert.strictEqual(committed.txId, computeEntryTxId(e).toString('hex'));
 
         // Reveal
         const revealed = await add.reveal(factomd, e, PAYING_EC_ADDRESS);
-        assert.equal(revealed.entryHash, e.hashHex());
-        assert.equal(revealed.chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
+        assert.strictEqual(revealed.entryHash, e.hashHex());
+        assert.strictEqual(revealed.chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
     });
 
     it('should reject commit entry without chainId', async function () {
@@ -103,10 +103,10 @@ describe('Add chains and entries in Factom blockchain', function () {
 
         const added = await add.add(factomd, c, PAYING_EC_ADDRESS);
 
-        assert.equal(added.entryHash, c.firstEntry.hashHex());
-        assert.equal(added.chainId, c.idHex);
-        assert.equal(added.repeatedCommit, false);
-        assert.equal(added.txId, computeChainTxId(c).toString('hex'));
+        assert.strictEqual(added.entryHash, c.firstEntry.hashHex());
+        assert.strictEqual(added.chainId, c.idHex);
+        assert.strictEqual(added.repeatedCommit, false);
+        assert.strictEqual(added.txId, computeChainTxId(c).toString('hex'));
     });
 
     it('should notify repeated commit', async function () {
@@ -123,7 +123,7 @@ describe('Add chains and entries in Factom blockchain', function () {
 
         await add.commit(factomd, c, PAYING_EC_ADDRESS);
         const repeated = await add.commit(factomd, c, PAYING_EC_ADDRESS);
-        assert.equal(repeated.repeatedCommit, true);
+        assert.strictEqual(repeated.repeatedCommit, true);
         assert.isUndefined(repeated.txId);
     });
 
@@ -140,10 +140,10 @@ describe('Add chains and entries in Factom blockchain', function () {
 
         const added = await add.add(factomd, e, PAYING_EC_ADDRESS);
 
-        assert.equal(added.entryHash, e.hashHex());
-        assert.equal(added.chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
-        assert.equal(added.repeatedCommit, false);
-        assert.equal(added.txId, computeEntryTxId(e).toString('hex'));
+        assert.strictEqual(added.entryHash, e.hashHex());
+        assert.strictEqual(added.chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
+        assert.strictEqual(added.repeatedCommit, false);
+        assert.strictEqual(added.txId, computeEntryTxId(e).toString('hex'));
     });
 
     it('should reject add entry without chainId', async function () {
@@ -186,10 +186,10 @@ describe('Add chains and entries in Factom blockchain', function () {
         const added = await add.add(factomd, [e1, e2], PAYING_EC_ADDRESS, { chunkSize: 1 });
 
         assert.lengthOf(added, 2);
-        assert.equal(added[0].entryHash, e1.hashHex());
-        assert.equal(added[0].chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
-        assert.equal(added[0].repeatedCommit, false);
-        assert.equal(added[0].txId, computeEntryTxId(e1).toString('hex'));
+        assert.strictEqual(added[0].entryHash, e1.hashHex());
+        assert.strictEqual(added[0].chainId, '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
+        assert.strictEqual(added[0].repeatedCommit, false);
+        assert.strictEqual(added[0].txId, computeEntryTxId(e1).toString('hex'));
     });
 
     it('should add chains', async function () {
@@ -214,10 +214,10 @@ describe('Add chains and entries in Factom blockchain', function () {
         const added = await add.add(factomd, [c1, c2], PAYING_EC_ADDRESS, { chunkSize: 1 });
 
         assert.lengthOf(added, 2);
-        assert.equal(added[0].entryHash, c1.firstEntry.hashHex());
-        assert.equal(added[0].chainId, c1.idHex);
-        assert.equal(added[0].repeatedCommit, false);
-        assert.equal(added[0].txId, computeChainTxId(c1).toString('hex'));
+        assert.strictEqual(added[0].entryHash, c1.firstEntry.hashHex());
+        assert.strictEqual(added[0].chainId, c1.idHex);
+        assert.strictEqual(added[0].repeatedCommit, false);
+        assert.strictEqual(added[0].txId, computeChainTxId(c1).toString('hex'));
     });
 
     it('should throw when adding an already existing chain', async function () {

--- a/test/addresses.unit.spec.js
+++ b/test/addresses.unit.spec.js
@@ -73,47 +73,47 @@ describe('Test addresses', function() {
     });
 
     it('should get public address from already public address', function() {
-        assert.equal(addresses.getPublicAddress('EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD'), 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD');
-        assert.equal(addresses.getPublicAddress('FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG'), 'FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG');
+        assert.strictEqual(addresses.getPublicAddress('EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD'), 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD');
+        assert.strictEqual(addresses.getPublicAddress('FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG'), 'FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG');
     });
 
     it('should get public address from private address', function() {
-        assert.equal(addresses.getPublicAddress('Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym'), 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD');
-        assert.equal(addresses.getPublicAddress('Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X'), 'FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG');
+        assert.strictEqual(addresses.getPublicAddress('Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym'), 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD');
+        assert.strictEqual(addresses.getPublicAddress('Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X'), 'FA29jNtT88wGjs9YLQch8ur4VFaTDkuiDwWe1YmksPDJuh3tAczG');
     });
 
     it('should get public Factoid address out of key', function() {
         const key = Buffer.from('776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80', 'hex');
 
-        assert.equal(addresses.keyToPublicFctAddress(key), 'FA3qqJ2gFngBYc4AkvcBYWXTh6Bv1jdUMEmafxsLgw1jZ3dGq1ye');
-        assert.equal(addresses.keyToPublicFctAddress(key).toString('hex'), 'FA3qqJ2gFngBYc4AkvcBYWXTh6Bv1jdUMEmafxsLgw1jZ3dGq1ye');
+        assert.strictEqual(addresses.keyToPublicFctAddress(key), 'FA3qqJ2gFngBYc4AkvcBYWXTh6Bv1jdUMEmafxsLgw1jZ3dGq1ye');
+        assert.strictEqual(addresses.keyToPublicFctAddress(key).toString('hex'), 'FA3qqJ2gFngBYc4AkvcBYWXTh6Bv1jdUMEmafxsLgw1jZ3dGq1ye');
     });
 
     it('should get public Factoid address out of RCD hash', function() {
         const key = Buffer.from('776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80', 'hex');
 
-        assert.equal(addresses.rcdHashToPublicFctAddress(key), 'FA2sfxwHGxz5kVXnKy2osu14mV8xZ3zhLs76DekB6LdgmBy5uz1q');
-        assert.equal(addresses.rcdHashToPublicFctAddress(key).toString('hex'), 'FA2sfxwHGxz5kVXnKy2osu14mV8xZ3zhLs76DekB6LdgmBy5uz1q');
+        assert.strictEqual(addresses.rcdHashToPublicFctAddress(key), 'FA2sfxwHGxz5kVXnKy2osu14mV8xZ3zhLs76DekB6LdgmBy5uz1q');
+        assert.strictEqual(addresses.rcdHashToPublicFctAddress(key).toString('hex'), 'FA2sfxwHGxz5kVXnKy2osu14mV8xZ3zhLs76DekB6LdgmBy5uz1q');
     });
 
     it('should get private Factoid address out of seed', function() {
         const seed = Buffer.from('776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80', 'hex');
 
-        assert.equal(addresses.seedToPrivateFctAddress(seed), 'Fs2E6iXCLAKDiPqVtfxtuQCKsTe7o6DJFDnht1wST53s4ibtdu9f');
-        assert.equal(addresses.seedToPrivateFctAddress(seed).toString('hex'), 'Fs2E6iXCLAKDiPqVtfxtuQCKsTe7o6DJFDnht1wST53s4ibtdu9f');
+        assert.strictEqual(addresses.seedToPrivateFctAddress(seed), 'Fs2E6iXCLAKDiPqVtfxtuQCKsTe7o6DJFDnht1wST53s4ibtdu9f');
+        assert.strictEqual(addresses.seedToPrivateFctAddress(seed).toString('hex'), 'Fs2E6iXCLAKDiPqVtfxtuQCKsTe7o6DJFDnht1wST53s4ibtdu9f');
     });
 
     it('should get public Entry Credit address out of key', function() {
         const key = Buffer.from('776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80', 'hex');
-        assert.equal(addresses.keyToPublicEcAddress(key), 'EC2fkBUHv13xLBhio8QfD69CjFXubnJa9z5kKzSk8GeWiapAw457');
-        assert.equal(addresses.keyToPublicEcAddress(key).toString('hex'), 'EC2fkBUHv13xLBhio8QfD69CjFXubnJa9z5kKzSk8GeWiapAw457');
+        assert.strictEqual(addresses.keyToPublicEcAddress(key), 'EC2fkBUHv13xLBhio8QfD69CjFXubnJa9z5kKzSk8GeWiapAw457');
+        assert.strictEqual(addresses.keyToPublicEcAddress(key).toString('hex'), 'EC2fkBUHv13xLBhio8QfD69CjFXubnJa9z5kKzSk8GeWiapAw457');
     });
 
     it('should get private Entry Credit address out of key', function() {
         const seed = Buffer.from('776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80', 'hex');
 
-        assert.equal(addresses.seedToPrivateEcAddress(seed), 'Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV');
-        assert.equal(addresses.seedToPrivateEcAddress(seed).toString('hex'), 'Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV');
+        assert.strictEqual(addresses.seedToPrivateEcAddress(seed), 'Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV');
+        assert.strictEqual(addresses.seedToPrivateEcAddress(seed).toString('hex'), 'Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV');
     });
 
     it('should reject to get public key from public Factoid addresses', function() {
@@ -121,23 +121,23 @@ describe('Test addresses', function() {
     });
 
     it('should extract cryptographic keys from addresses', function() {
-        assert.equal(addresses.addressToKey('EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD').toString('hex'), '98fb8ffa591adc5f20ee4887affe06c18ca3b97cbda1a74a12944c1c26fdf864');
-        assert.equal(addresses.addressToKey('Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV').toString('hex'), '776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80');
-        assert.equal(addresses.addressToKey('Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X').toString('hex'), 'd48189215e445ea7e8dbf707c48922ab25a23552d8eae40cc5e9cd6b1a36963c');
+        assert.strictEqual(addresses.addressToKey('EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD').toString('hex'), '98fb8ffa591adc5f20ee4887affe06c18ca3b97cbda1a74a12944c1c26fdf864');
+        assert.strictEqual(addresses.addressToKey('Es3LFXNj5vHBw8c9kM98HKR69CJjUTyTPv4BdxoRbMQJ8zifxkgV').toString('hex'), '776b5cf08edea510711e2bc4a73f2b5118008906c5afd2e5786cf817fa279b80');
+        assert.strictEqual(addresses.addressToKey('Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X').toString('hex'), 'd48189215e445ea7e8dbf707c48922ab25a23552d8eae40cc5e9cd6b1a36963c');
     });
 
     it('should generate random FCT address', function() {
         const randomAddress = addresses.generateRandomFctAddress();
         assert.isTrue(addresses.isValidPublicFctAddress(randomAddress.public));
         assert.isTrue(addresses.isValidPrivateFctAddress(randomAddress.private));
-        assert.equal(addresses.getPublicAddress(randomAddress.private), randomAddress.public);
+        assert.strictEqual(addresses.getPublicAddress(randomAddress.private), randomAddress.public);
     });
 
     it('should generate random EC address', function() {
         const randomAddress = addresses.generateRandomEcAddress();
         assert.isTrue(addresses.isValidPublicEcAddress(randomAddress.public));
         assert.isTrue(addresses.isValidPrivateEcAddress(randomAddress.private));
-        assert.equal(addresses.getPublicAddress(randomAddress.private), randomAddress.public);
+        assert.strictEqual(addresses.getPublicAddress(randomAddress.private), randomAddress.public);
     });
     
     

--- a/test/blocks.unit.spec.js
+++ b/test/blocks.unit.spec.js
@@ -1,23 +1,22 @@
 const assert = require('chai').assert,
     { EntryCreditBlock, AdminBlock } = require('../src/blocks');
 
-
 describe('Test Blocks', function() {
 
     it('should populate EntryCreditBlock', function() {
         const ecb = new EntryCreditBlock(require('./data/entry-credit-block.json'));
 
         assert.instanceOf(ecb, EntryCreditBlock);
-        assert.equal(ecb.headerHash, 'b5ba1c807443113650ecc565db3023233a1ab1179674c788891fd89e083021ec');
-        assert.equal(ecb.fullHash, '7772b118e454c2730286647801b7e5e543163db0dcfe96de64d08a4322614012');
+        assert.strictEqual(ecb.headerHash, 'b5ba1c807443113650ecc565db3023233a1ab1179674c788891fd89e083021ec');
+        assert.strictEqual(ecb.fullHash, '7772b118e454c2730286647801b7e5e543163db0dcfe96de64d08a4322614012');
 
-        assert.equal(ecb.bodyHash, '164f3d2a9fdfbf5c5c6dfe0814ac9b522620ae486619d44d076eaea97e2e9482');
-        assert.equal(ecb.previousHeaderHash, 'e716f2ef7baa5663e52aebeac46a6548c71fe4a2e7a9e687014afea862f2a836');
-        assert.equal(ecb.previousFullHash, '952856e6e35afb8e5cfa8c893a6d383695562b4ea3c4981290c7da3fef03a2f7');
-        assert.equal(ecb.directoryBlockHeight, 132099);
-        assert.equal(ecb.headerExpansionArea, '');
-        assert.equal(ecb.objectCount, 59);
-        assert.equal(ecb.bodySize, 6733);
+        assert.strictEqual(ecb.bodyHash, '164f3d2a9fdfbf5c5c6dfe0814ac9b522620ae486619d44d076eaea97e2e9482');
+        assert.strictEqual(ecb.previousHeaderHash, 'e716f2ef7baa5663e52aebeac46a6548c71fe4a2e7a9e687014afea862f2a836');
+        assert.strictEqual(ecb.previousFullHash, '952856e6e35afb8e5cfa8c893a6d383695562b4ea3c4981290c7da3fef03a2f7');
+        assert.strictEqual(ecb.directoryBlockHeight, 132099);
+        assert.strictEqual(ecb.headerExpansionArea, '');
+        assert.strictEqual(ecb.objectCount, 59);
+        assert.strictEqual(ecb.bodySize, 6733);
 
         assert.lengthOf(ecb.commits, 49);
         assert.lengthOf(ecb.getCommitsForMinute(1), 1);
@@ -32,51 +31,51 @@ describe('Test Blocks', function() {
         assert.lengthOf(ecb.getCommitsForMinute(10), 11);
 
         const commit = ecb.getCommitsForMinute(1)[0];
-        assert.equal(commit.version, 0);
-        assert.equal(commit.millis, 1521084063230);
-        assert.equal(commit.entryHash, '57cf6740c4f30ae39d71f75710fb4ea9c843d5c01755329a42ccab52034e1f79');
-        assert.equal(commit.credits, 1);
-        assert.equal(commit.signature, '3e6e7d85a201b398d6bc056213f698d6fed7d1e82813105b7310b843618b228c2559dd1f3a22f1dd28d97f2fdcde86cff59415753fc4b826b2bfe5f7425b780d');
-        assert.equal(commit.ecPublicKey, 'EC3PH2S2iXP4WpfoLuU5ETWRNfNZnmNUF5epWoFweYmBx9m4xK3z');
+        assert.strictEqual(commit.version, 0);
+        assert.strictEqual(commit.millis, 1521084063230);
+        assert.strictEqual(commit.entryHash, '57cf6740c4f30ae39d71f75710fb4ea9c843d5c01755329a42ccab52034e1f79');
+        assert.strictEqual(commit.credits, 1);
+        assert.strictEqual(commit.signature, '3e6e7d85a201b398d6bc056213f698d6fed7d1e82813105b7310b843618b228c2559dd1f3a22f1dd28d97f2fdcde86cff59415753fc4b826b2bfe5f7425b780d');
+        assert.strictEqual(commit.ecPublicKey, 'EC3PH2S2iXP4WpfoLuU5ETWRNfNZnmNUF5epWoFweYmBx9m4xK3z');
     });
 
     it('should populate M1 EntryCreditBlock', function() {
         const ecb = new EntryCreditBlock(require('./data/m1-entry-credit-block.json'));
 
         assert.instanceOf(ecb, EntryCreditBlock);
-        assert.equal(ecb.headerHash, 'b9202c7882f5e3f11f806bdb9bec287f3674888c974fd1168710043ef1210052');
-        assert.equal(ecb.fullHash, 'c57abb3398fd718d8aef3d9e75aba3b0e051403be42eb0503730ad2fa68912a4');
+        assert.strictEqual(ecb.headerHash, 'b9202c7882f5e3f11f806bdb9bec287f3674888c974fd1168710043ef1210052');
+        assert.strictEqual(ecb.fullHash, 'c57abb3398fd718d8aef3d9e75aba3b0e051403be42eb0503730ad2fa68912a4');
 
-        assert.equal(ecb.bodyHash, '4b0fcbae01e6aeff813b87a7b1e621eb210fad39135d7fd467636af037c6f83b');
-        assert.equal(ecb.previousHeaderHash, '3ce8487a8e2c71ae4d2f130c7b7ebfe30bad632dcf6cad689b2a66de218a169a');
-        assert.equal(ecb.previousFullHash, 'f887c945240496c8ec865100bbdad292d034ee7881f88d7452b949e48c022227');
-        assert.equal(ecb.directoryBlockHeight, 53037);
-        assert.equal(ecb.headerExpansionArea, '');
-        assert.equal(ecb.objectCount, 147);
-        assert.equal(ecb.bodySize, 18586);
+        assert.strictEqual(ecb.bodyHash, '4b0fcbae01e6aeff813b87a7b1e621eb210fad39135d7fd467636af037c6f83b');
+        assert.strictEqual(ecb.previousHeaderHash, '3ce8487a8e2c71ae4d2f130c7b7ebfe30bad632dcf6cad689b2a66de218a169a');
+        assert.strictEqual(ecb.previousFullHash, 'f887c945240496c8ec865100bbdad292d034ee7881f88d7452b949e48c022227');
+        assert.strictEqual(ecb.directoryBlockHeight, 53037);
+        assert.strictEqual(ecb.headerExpansionArea, '');
+        assert.strictEqual(ecb.objectCount, 147);
+        assert.strictEqual(ecb.bodySize, 18586);
 
         assert.lengthOf(ecb.commits, 135);
 
         const commit = ecb.getCommitsForMinute(1)[0];
-        assert.equal(commit.version, 0);
-        assert.equal(commit.millis, 1473040801697);
-        assert.equal(commit.entryHash, 'df72b3c35f3ac80820b1196570d5028e66e04f8cb5a3b90b5dd486a60743e014');
-        assert.equal(commit.credits, 1);
-        assert.equal(commit.signature, '07a2c43f156117ca3567dedd42533b66b718ab991a7b8fa86bbc0307b007a6e03837a38311b0b7515643e46714b8e6bc0a417cd4f899fe75cd4a29cfdfbef209');
-        assert.equal(commit.ecPublicKey, 'EC2LXsumFsDK36ueRdNZC5Q3zMhxCzoZXM52JRtsgCfyQUruYXLY');
+        assert.strictEqual(commit.version, 0);
+        assert.strictEqual(commit.millis, 1473040801697);
+        assert.strictEqual(commit.entryHash, 'df72b3c35f3ac80820b1196570d5028e66e04f8cb5a3b90b5dd486a60743e014');
+        assert.strictEqual(commit.credits, 1);
+        assert.strictEqual(commit.signature, '07a2c43f156117ca3567dedd42533b66b718ab991a7b8fa86bbc0307b007a6e03837a38311b0b7515643e46714b8e6bc0a417cd4f899fe75cd4a29cfdfbef209');
+        assert.strictEqual(commit.ecPublicKey, 'EC2LXsumFsDK36ueRdNZC5Q3zMhxCzoZXM52JRtsgCfyQUruYXLY');
     });
 
     it('should parse AdminBlock', function() {
         const adminBlocks = require('./data/admin-blocks.json');
 
         const ablock1 = new AdminBlock(adminBlocks['15a887568ba62cfe0df15b27956a0c65a3862688e96d550519b3d3cb07b4c070']);
-        assert.equal(ablock1.lookupHash, '15a887568ba62cfe0df15b27956a0c65a3862688e96d550519b3d3cb07b4c070');
-        assert.equal(ablock1.backReferenceHash, 'a93018e3032bc783d317a9c38a3e927f40017a212b0c73b732386f14750174ec');
-        assert.equal(ablock1.directoryBlockHeight, 31096);
-        assert.equal(ablock1.previousBackReferenceHash, 'ed78955c3d3dc91d9cc55be8d30171b1685d2984c0940c89edc14ec2cce067ef');
-        assert.equal(ablock1.headerExpansionSize, 0);
-        assert.equal(ablock1.headerExpansionArea, '');
-        assert.equal(ablock1.bodySize, 1032);
+        assert.strictEqual(ablock1.lookupHash, '15a887568ba62cfe0df15b27956a0c65a3862688e96d550519b3d3cb07b4c070');
+        assert.strictEqual(ablock1.backReferenceHash, 'a93018e3032bc783d317a9c38a3e927f40017a212b0c73b732386f14750174ec');
+        assert.strictEqual(ablock1.directoryBlockHeight, 31096);
+        assert.strictEqual(ablock1.previousBackReferenceHash, 'ed78955c3d3dc91d9cc55be8d30171b1685d2984c0940c89edc14ec2cce067ef');
+        assert.strictEqual(ablock1.headerExpansionSize, 0);
+        assert.strictEqual(ablock1.headerExpansionArea, '');
+        assert.strictEqual(ablock1.bodySize, 1032);
         assert.lengthOf(ablock1.entries, 8);
         assert.lengthOf(ablock1.getEntriesOfTypes(1), 8);
         assert.lengthOf(ablock1.getEntriesOfTypes('DIRECTORY_BLOCK_SIGNATURE'), 8);
@@ -85,7 +84,6 @@ describe('Test Blocks', function() {
         assert.lengthOf(ablock2.getEntriesOfTypes(1), 9);
         assert.lengthOf(ablock2.getEntriesOfTypes(6), 1);
         assert.lengthOf(ablock2.getEntriesOfTypes('ADD_REPLACE_MATRYOSHKA_HASH'), 1);
-
     });
 
     it('should parse AdminBlock entry type 1', function() {
@@ -93,11 +91,11 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['15a887568ba62cfe0df15b27956a0c65a3862688e96d550519b3d3cb07b4c070']);
         const entry = ablock.entries[0];
-        assert.equal(entry.adminId, 1);
-        assert.equal(entry.adminCode, 'DIRECTORY_BLOCK_SIGNATURE');
-        assert.equal(entry.identityChainId, '8888881c98618455b818cbe56b924374d87445ffdc7263363302292974dc3f94');
-        assert.equal(entry.previousDirectoryBlockSignature.publicKey, '0de6369919f526225a14c38b7cf7081287e4029471e000b5c4336c041b233253');
-        assert.equal(entry.previousDirectoryBlockSignature.signature, 'ccdf572fd75b6618ce182096e395974717d0b1b9306b50660b8958f0e45961b495484894ea6b51cd8b77aed0909f965c0ee5566a2d54d58dc7c7f19a2dfb1f0a');
+        assert.strictEqual(entry.adminId, 1);
+        assert.strictEqual(entry.adminCode, 'DIRECTORY_BLOCK_SIGNATURE');
+        assert.strictEqual(entry.identityChainId, '8888881c98618455b818cbe56b924374d87445ffdc7263363302292974dc3f94');
+        assert.strictEqual(entry.previousDirectoryBlockSignature.publicKey, '0de6369919f526225a14c38b7cf7081287e4029471e000b5c4336c041b233253');
+        assert.strictEqual(entry.previousDirectoryBlockSignature.signature, 'ccdf572fd75b6618ce182096e395974717d0b1b9306b50660b8958f0e45961b495484894ea6b51cd8b77aed0909f965c0ee5566a2d54d58dc7c7f19a2dfb1f0a');
     });
 
     it('should parse AdminBlock entry type 3', function() {
@@ -105,10 +103,10 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_REPLACE_MATRYOSHKA_HASH')[0];
-        assert.equal(entry.adminId, 3);
-        assert.equal(entry.adminCode, 'ADD_REPLACE_MATRYOSHKA_HASH');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.matryoshkaHash, '4e99c3725c51d4cecf7de78e3196166e6de12a12f68b437b9c43f71b459979c6');
+        assert.strictEqual(entry.adminId, 3);
+        assert.strictEqual(entry.adminCode, 'ADD_REPLACE_MATRYOSHKA_HASH');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.matryoshkaHash, '4e99c3725c51d4cecf7de78e3196166e6de12a12f68b437b9c43f71b459979c6');
     });
 
     it('should parse AdminBlock entry type 5', function() {
@@ -116,10 +114,10 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['60df6174ef83475e54fe01f246710f8ea1cb29b2681433bbabd57ed8081f9739']);
         const entry = ablock.getEntriesOfTypes('ADD_FEDERATED_SERVER')[0];
-        assert.equal(entry.adminId, 5);
-        assert.equal(entry.adminCode, 'ADD_FEDERATED_SERVER');
-        assert.equal(entry.identityChainId, '8888881c98618455b818cbe56b924374d87445ffdc7263363302292974dc3f94');
-        assert.equal(entry.directoryBlockHeight, 30943);
+        assert.strictEqual(entry.adminId, 5);
+        assert.strictEqual(entry.adminCode, 'ADD_FEDERATED_SERVER');
+        assert.strictEqual(entry.identityChainId, '8888881c98618455b818cbe56b924374d87445ffdc7263363302292974dc3f94');
+        assert.strictEqual(entry.directoryBlockHeight, 30943);
     });
     
 
@@ -128,10 +126,10 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_AUDIT_SERVER')[0];
-        assert.equal(entry.adminId, 6);
-        assert.equal(entry.adminCode, 'ADD_AUDIT_SERVER');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.directoryBlockHeight, 30896);
+        assert.strictEqual(entry.adminId, 6);
+        assert.strictEqual(entry.adminCode, 'ADD_AUDIT_SERVER');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.directoryBlockHeight, 30896);
     });
 
     it('should parse AdminBlock entry type 7', function() {
@@ -139,10 +137,10 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['957919e27b7252423db4038db168bf4dfc3ce17b493ee0866e4fb91ae3c6edd3']);
         const entry = ablock.getEntriesOfTypes('REMOVE_FEDERATED_SERVER')[0];
-        assert.equal(entry.adminId, 7);
-        assert.equal(entry.adminCode, 'REMOVE_FEDERATED_SERVER');
-        assert.equal(entry.identityChainId, '888888b9f4fe1fea85d9ab55f84e1ec06aa135a905ef0865848d947c9c798f1f');
-        assert.equal(entry.directoryBlockHeight, 30751);
+        assert.strictEqual(entry.adminId, 7);
+        assert.strictEqual(entry.adminCode, 'REMOVE_FEDERATED_SERVER');
+        assert.strictEqual(entry.identityChainId, '888888b9f4fe1fea85d9ab55f84e1ec06aa135a905ef0865848d947c9c798f1f');
+        assert.strictEqual(entry.directoryBlockHeight, 30751);
     });
 
     it('should parse AdminBlock entry type 8', function() {
@@ -150,12 +148,12 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_FEDERATED_SERVER_SIGNING_KEY')[0];
-        assert.equal(entry.adminId, 8);
-        assert.equal(entry.adminCode, 'ADD_FEDERATED_SERVER_SIGNING_KEY');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.publicKey, '08ec6928e010c1694763d571e9a0142c697f524cc40d33ca7bd911d8685a1921');
-        assert.equal(entry.keyPriority, 0);
-        assert.equal(entry.directoryBlockHeight, 30896);
+        assert.strictEqual(entry.adminId, 8);
+        assert.strictEqual(entry.adminCode, 'ADD_FEDERATED_SERVER_SIGNING_KEY');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.publicKey, '08ec6928e010c1694763d571e9a0142c697f524cc40d33ca7bd911d8685a1921');
+        assert.strictEqual(entry.keyPriority, 0);
+        assert.strictEqual(entry.directoryBlockHeight, 30896);
     });
 
     it('should parse AdminBlock entry type 9', function() {
@@ -163,12 +161,12 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_FEDERATED_SERVER_BITCOIN_ANCHOR_KEY')[0];
-        assert.equal(entry.adminId, 9);
-        assert.equal(entry.adminCode, 'ADD_FEDERATED_SERVER_BITCOIN_ANCHOR_KEY');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.ecdsaPublicKey, '45185ad9f6453ac56a7572dbd9abbe2d421b0692');
-        assert.equal(entry.keyPriority, 0);
-        assert.equal(entry.keyType, 0);
+        assert.strictEqual(entry.adminId, 9);
+        assert.strictEqual(entry.adminCode, 'ADD_FEDERATED_SERVER_BITCOIN_ANCHOR_KEY');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.ecdsaPublicKey, '45185ad9f6453ac56a7572dbd9abbe2d421b0692');
+        assert.strictEqual(entry.keyPriority, 0);
+        assert.strictEqual(entry.keyType, 0);
     });
 
     it('should parse AdminBlock entry type 11', function() {
@@ -176,12 +174,12 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('COINBASE_DESCRIPTOR')[0];
-        assert.equal(entry.adminId, 11);
-        assert.equal(entry.adminCode, 'COINBASE_DESCRIPTOR');
+        assert.strictEqual(entry.adminId, 11);
+        assert.strictEqual(entry.adminCode, 'COINBASE_DESCRIPTOR');
         assert.lengthOf(entry.outputs, 9);
-        assert.equal(entry.outputs[0].address, 'FA3NCrf7W6CV4A7HKLQd4eveHhzfrayE3CXd85axLQrD4zYr4XbW');
-        assert.equal(entry.outputs[0].rcdHash, 'b834c8637b2b8c7f18e92243383391fba263a25d49f7a6280807e6824224dd28');
-        assert.equal(entry.outputs[0].amount, 320000000);
+        assert.strictEqual(entry.outputs[0].address, 'FA3NCrf7W6CV4A7HKLQd4eveHhzfrayE3CXd85axLQrD4zYr4XbW');
+        assert.strictEqual(entry.outputs[0].rcdHash, 'b834c8637b2b8c7f18e92243383391fba263a25d49f7a6280807e6824224dd28');
+        assert.strictEqual(entry.outputs[0].amount, 320000000);
     });
 
     it('should parse AdminBlock entry type 12', function() {
@@ -189,10 +187,10 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['dcd88117e8233efe279c371eb54bc0c73bc2c8627a9c5a8be3de74b8b9afa2d4']);
         const entry = ablock.getEntriesOfTypes('COINBASE_DESCRIPTOR_CANCEL')[0];
-        assert.equal(entry.adminId, 12);
-        assert.equal(entry.adminCode, 'COINBASE_DESCRIPTOR_CANCEL');
-        assert.equal(entry.descriptorHeight, 46460);
-        assert.equal(entry.descriptorIndex, 8);
+        assert.strictEqual(entry.adminId, 12);
+        assert.strictEqual(entry.adminCode, 'COINBASE_DESCRIPTOR_CANCEL');
+        assert.strictEqual(entry.descriptorHeight, 46460);
+        assert.strictEqual(entry.descriptorIndex, 8);
     });
 
     it('should parse AdminBlock entry type 13', function() {
@@ -200,11 +198,11 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_AUTHORITY_FACTOID_ADDRESS')[0];
-        assert.equal(entry.adminId, 13);
-        assert.equal(entry.adminCode, 'ADD_AUTHORITY_FACTOID_ADDRESS');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.factoidAddress, 'FA3NCrf7W6CV4A7HKLQd4eveHhzfrayE3CXd85axLQrD4zYr4XbW');
-        assert.equal(entry.rcdHash, 'b834c8637b2b8c7f18e92243383391fba263a25d49f7a6280807e6824224dd28');
+        assert.strictEqual(entry.adminId, 13);
+        assert.strictEqual(entry.adminCode, 'ADD_AUTHORITY_FACTOID_ADDRESS');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.factoidAddress, 'FA3NCrf7W6CV4A7HKLQd4eveHhzfrayE3CXd85axLQrD4zYr4XbW');
+        assert.strictEqual(entry.rcdHash, 'b834c8637b2b8c7f18e92243383391fba263a25d49f7a6280807e6824224dd28');
     });
 
     it('should parse AdminBlock entry type 14', function() {
@@ -212,10 +210,9 @@ describe('Test Blocks', function() {
 
         const ablock = new AdminBlock(adminBlocks['8a0a37bd123b0e210eeed8a6cad22fb742bd52d123d9b42af4e9901052a66a0d']);
         const entry = ablock.getEntriesOfTypes('ADD_AUTHORITY_EFFICIENCY')[0];
-        assert.equal(entry.adminId, 14);
-        assert.equal(entry.adminCode, 'ADD_AUTHORITY_EFFICIENCY');
-        assert.equal(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
-        assert.equal(entry.efficiency, 50);
-  
+        assert.strictEqual(entry.adminId, 14);
+        assert.strictEqual(entry.adminCode, 'ADD_AUTHORITY_EFFICIENCY');
+        assert.strictEqual(entry.identityChainId, '8888880732ebbec169b8e583c6ac6f9a348692aca6457cab5025e104fbadc282');
+        assert.strictEqual(entry.efficiency, 50);
     });
 });

--- a/test/chain.unit.spec.js
+++ b/test/chain.unit.spec.js
@@ -16,9 +16,9 @@ describe('Test Chain', function () {
         const chain = new Chain(entry);
 
         assert.instanceOf(chain.id, Buffer);
-        assert.equal(chain.id.toString('hex'), '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
-        assert.equal(chain.idHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
-        assert.equal(chain.firstEntry.chainIdHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
+        assert.strictEqual(chain.id.toString('hex'), '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
+        assert.strictEqual(chain.idHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
+        assert.strictEqual(chain.firstEntry.chainIdHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
     });
 
     it('should reject invalid argument of Chain constructor', function () {
@@ -41,8 +41,8 @@ describe('Test Chain', function () {
 
         const chain = new Chain(entry);
 
-        assert.equal(chain.idHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
-        assert.equal(chain.firstEntry.chainIdHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
+        assert.strictEqual(chain.idHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
+        assert.strictEqual(chain.firstEntry.chainIdHex, '954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f4');
     });
 
     it('should compute EC cost', function () {
@@ -55,7 +55,7 @@ describe('Test Chain', function () {
 
         const chain = new Chain(entry);
 
-        assert.equal(chain.ecCost(), 11);
+        assert.strictEqual(chain.ecCost(), 11);
     });
 
     it('should compose Chain commit', function () {
@@ -69,7 +69,7 @@ describe('Test Chain', function () {
 
         const commit = composeChainCommit(chain, 'Es2d1a3uPx7o5uXHmsCnSEK2EKatPA56n8RUFmW9uRrpPRBuk5bZ');
         assert.instanceOf(commit, Buffer);
-        assert.equal(commit.toString('hex'),
+        assert.strictEqual(commit.toString('hex'),
             '000162a772f640448ee02e500a8e539bcf5c02e53f8b88fc1f81f0a87d0f18af94ab9384992b5c9db26ac6b20aba137815efc39cf19cee53de0baccc54ec4e6acc6b02ffe4b936b56a6bbae773f5b51001161efdeb0ba1e8447f3c45206119b40539e4325cc5be0b5d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
     });
 
@@ -99,7 +99,7 @@ describe('Test Chain', function () {
 
         const commit = composeChainCommit(chain, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR', 'a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
         assert.instanceOf(commit, Buffer);
-        assert.equal(commit.toString('hex'),
+        assert.strictEqual(commit.toString('hex'),
             '000162a772f640448ee02e500a8e539bcf5c02e53f8b88fc1f81f0a87d0f18af94ab9384992b5c9db26ac6b20aba137815efc39cf19cee53de0baccc54ec4e6acc6b02ffe4b936b56a6bbae773f5b51001161efdeb0ba1e8447f3c45206119b40539e4325cc5be0b5d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
     });
 
@@ -134,7 +134,7 @@ describe('Test Chain', function () {
 
         const reveal = composeChainReveal(chain);
         assert.instanceOf(reveal, Buffer);
-        assert.equal(reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
     });
 
     it('should compose Chain commit and reveal', function () {
@@ -148,9 +148,9 @@ describe('Test Chain', function () {
         const composed = composeChain(chain, 'Es2d1a3uPx7o5uXHmsCnSEK2EKatPA56n8RUFmW9uRrpPRBuk5bZ');
         assert.instanceOf(composed.commit, Buffer);
         assert.instanceOf(composed.reveal, Buffer);
-        assert.equal(composed.commit.toString('hex'),
+        assert.strictEqual(composed.commit.toString('hex'),
             '000162a772f640448ee02e500a8e539bcf5c02e53f8b88fc1f81f0a87d0f18af94ab9384992b5c9db26ac6b20aba137815efc39cf19cee53de0baccc54ec4e6acc6b02ffe4b936b56a6bbae773f5b51001161efdeb0ba1e8447f3c45206119b40539e4325cc5be0b5d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
-        assert.equal(composed.reveal.toString('hex'), '00fcfe632c6ab1a7c71448e256e0487c4cfc34ceac90e997de8c4fdf8485e9a0fd001900176d79206578742069642031373834343635353737373935');
+        assert.strictEqual(composed.reveal.toString('hex'), '00fcfe632c6ab1a7c71448e256e0487c4cfc34ceac90e997de8c4fdf8485e9a0fd001900176d79206578742069642031373834343635353737373935');
     });
 
     it('should compose Chain commit and reveal', function () {
@@ -164,9 +164,9 @@ describe('Test Chain', function () {
         const composed = composeChain(chain, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR', 'a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
         assert.instanceOf(composed.commit, Buffer);
         assert.instanceOf(composed.reveal, Buffer);
-        assert.equal(composed.commit.toString('hex'),
+        assert.strictEqual(composed.commit.toString('hex'),
             '000162a772f640448ee02e500a8e539bcf5c02e53f8b88fc1f81f0a87d0f18af94ab9384992b5c9db26ac6b20aba137815efc39cf19cee53de0baccc54ec4e6acc6b02ffe4b936b56a6bbae773f5b51001161efdeb0ba1e8447f3c45206119b40539e4325cc5be0b5d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6a523cd0ebb71b13ec133eeb93c084958f1ed6adef51ec9ec6323c543f91303739c9e5194972c5105929b7787d327755ab1b5cf1b2884d4877b8fdcbca1cfb00b');
-        assert.equal(composed.reveal.toString('hex'), '00fcfe632c6ab1a7c71448e256e0487c4cfc34ceac90e997de8c4fdf8485e9a0fd001900176d79206578742069642031373834343635353737373935');
+        assert.strictEqual(composed.reveal.toString('hex'), '00fcfe632c6ab1a7c71448e256e0487c4cfc34ceac90e997de8c4fdf8485e9a0fd001900176d79206578742069642031373834343635353737373935');
     });
 
     it('should compute chain txId', function () {
@@ -181,7 +181,7 @@ describe('Test Chain', function () {
 
         const txId = computeChainTxId(chain);
         assert.instanceOf(txId, Buffer);
-        assert.equal(txId.toString('hex'), '3c22e7bb1b69818508d47056230317a9791158d96e7adb83b4596d77b6548a00');
+        assert.strictEqual(txId.toString('hex'), '3c22e7bb1b69818508d47056230317a9791158d96e7adb83b4596d77b6548a00');
     });
 
 
@@ -197,10 +197,10 @@ describe('Test Chain', function () {
         const chainCopy = new Chain(chain);
 
         assert.instanceOf(chainCopy, Chain);
-        assert.notEqual(chain, chainCopy);
-        assert.notEqual(chain.firstEntry, chainCopy.firstEntry);
-        assert.deepEqual(chain, chainCopy);
-        assert.deepEqual(chain.firstEntry, chainCopy.firstEntry);
+        assert.notStrictEqual(chain, chainCopy);
+        assert.notStrictEqual(chain.firstEntry, chainCopy.firstEntry);
+        assert.deepStrictEqual(chain, chainCopy);
+        assert.deepStrictEqual(chain.firstEntry, chainCopy.firstEntry);
     });
 
     it('should compute chain id', function () {
@@ -211,7 +211,7 @@ describe('Test Chain', function () {
             .build();
 
         const chainId = computeChainId(entry);
-        assert.equal(chainId.toString('hex'), '65f5107b51dcb02173318a6f2b79018a41aa281d9dfd1d53eda773647a6b4441');
+        assert.strictEqual(chainId.toString('hex'), '65f5107b51dcb02173318a6f2b79018a41aa281d9dfd1d53eda773647a6b4441');
     });
 
     it('should convert to JS object', function () {
@@ -225,8 +225,8 @@ describe('Test Chain', function () {
         const chain = new Chain(e);
         const obj = chain.toObject();
 
-        assert.equal(obj.id, chain.idHex);
-        assert.equal(obj.firstEntry.content, e.contentHex);
+        assert.strictEqual(obj.id, chain.idHex);
+        assert.strictEqual(obj.firstEntry.content, e.contentHex);
     });
 
 });

--- a/test/entry.unit.spec.js
+++ b/test/entry.unit.spec.js
@@ -15,16 +15,16 @@ describe('Test Entry', function () {
             .build();
 
         assert.instanceOf(entry.chainId, Buffer);
-        assert.equal(entry.chainId.toString('hex'), 'cfb5d93e747d20433e3b14603f90a5eb152d0399e7278f9671ecf9763f8780e8');
+        assert.strictEqual(entry.chainId.toString('hex'), 'cfb5d93e747d20433e3b14603f90a5eb152d0399e7278f9671ecf9763f8780e8');
         assert.instanceOf(entry.content, Buffer);
-        assert.equal(entry.content.toString(), 'hello');
+        assert.strictEqual(entry.content.toString(), 'hello');
         assert.instanceOf(entry.extIds, Array);
         assert.lengthOf(entry.extIds, 3);
         assert.instanceOf(entry.extIds[0], Buffer);
-        assert.equal(entry.extIds[0].toString(), 'extId');
-        assert.equal(entry.extIds[1].toString(), 'luap');
-        assert.equal(entry.extIds[2].toString(), 'extId2');
-        assert.equal(entry.timestamp, 1523072354);
+        assert.strictEqual(entry.extIds[0].toString(), 'extId');
+        assert.strictEqual(entry.extIds[1].toString(), 'luap');
+        assert.strictEqual(entry.extIds[2].toString(), 'extId2');
+        assert.strictEqual(entry.timestamp, 1523072354);
     });
 
     it('should reject invalid argument of Entry constructor', function () {
@@ -64,9 +64,9 @@ describe('Test Entry', function () {
             .content('hello', 'utf8')
             .build();
 
-        assert.equal(entry.size(), 55);
-        assert.equal(entry.payloadSize(), 20);
-        assert.equal(entry.rawDataSize(), 16);
+        assert.strictEqual(entry.size(), 55);
+        assert.strictEqual(entry.payloadSize(), 20);
+        assert.strictEqual(entry.rawDataSize(), 16);
 
     });
 
@@ -81,9 +81,9 @@ describe('Test Entry', function () {
 
         const copy = Entry.builder(entry).build();
 
-        assert.notEqual(entry, copy);
-        assert.notEqual(entry.extIds[0], copy.extIds[0]);
-        assert.notEqual(entry.content, copy.content);
+        assert.notStrictEqual(entry, copy);
+        assert.notStrictEqual(entry.extIds[0], copy.extIds[0]);
+        assert.notStrictEqual(entry.content, copy.content);
         assert.deepEqual(entry, copy);
     });
 
@@ -92,7 +92,7 @@ describe('Test Entry', function () {
 
         const copy = Entry.builder(entry).build();
 
-        assert.notEqual(entry, copy);
+        assert.notStrictEqual(entry, copy);
         assert.deepEqual(copy.chainId, Buffer.from(''));
         assert.deepEqual(copy.extIds, []);
         assert.deepEqual(copy.content, Buffer.from(''));
@@ -103,9 +103,9 @@ describe('Test Entry', function () {
             .content('abcdef', 'utf8')
             .build();
 
-        assert.equal(entry.size(), 41);
-        assert.equal(entry.payloadSize(), 6);
-        assert.equal(entry.rawDataSize(), 6);
+        assert.strictEqual(entry.size(), 41);
+        assert.strictEqual(entry.payloadSize(), 6);
+        assert.strictEqual(entry.rawDataSize(), 6);
     });
 
     it('should get remaining free bytes', function () {
@@ -122,10 +122,10 @@ describe('Test Entry', function () {
             .content(Buffer.alloc(0))
             .build();
 
-        assert.equal(e1.remainingFreeBytes(), 1000);
-        assert.equal(e2.remainingFreeBytes(), 0);
-        assert.equal(e3.remainingFreeBytes(), 1023);
-        assert.equal(e4.remainingFreeBytes(), 1024);
+        assert.strictEqual(e1.remainingFreeBytes(), 1000);
+        assert.strictEqual(e2.remainingFreeBytes(), 0);
+        assert.strictEqual(e3.remainingFreeBytes(), 1023);
+        assert.strictEqual(e4.remainingFreeBytes(), 1024);
     });
 
     it('should get remaining maximum bytes', function () {
@@ -139,8 +139,8 @@ describe('Test Entry', function () {
             .content(Buffer.alloc(e1.payloadSize() + e1.remainingMaxBytes() + 1))
             .build();
 
-        assert.equal(e1.remainingMaxBytes(), 10000);
-        assert.equal(e2.remainingMaxBytes(), 0);
+        assert.strictEqual(e1.remainingMaxBytes(), 10000);
+        assert.strictEqual(e2.remainingMaxBytes(), 0);
         assert.throws(() => e3.remainingMaxBytes(), Error);
     });
 
@@ -152,10 +152,10 @@ describe('Test Entry', function () {
             .content('45878755', 'hex')
             .build();
 
-        assert.equal(e.contentHex, '45878755');
-        assert.equal(e.extIdsHex[0], 'efef');
-        assert.equal(e.extIdsHex[1], '636f7666656665');
-        assert.equal(e.chainIdHex, '45f7ebb3be5217d0e2f1d14ab73121a66cdaad12a50b9863a45ee8ee9f3ab032');
+        assert.strictEqual(e.contentHex, '45878755');
+        assert.strictEqual(e.extIdsHex[0], 'efef');
+        assert.strictEqual(e.extIdsHex[1], '636f7666656665');
+        assert.strictEqual(e.chainIdHex, '45f7ebb3be5217d0e2f1d14ab73121a66cdaad12a50b9863a45ee8ee9f3ab032');
     });
 
     it('should compute marshal binary', function () {
@@ -173,9 +173,9 @@ describe('Test Entry', function () {
         const marshalBinary = e.marshalBinary();
         const marshalBinaryHex = e.marshalBinaryHex();
         assert.instanceOf(marshalBinary, Buffer);
-        assert.equal(marshalBinary.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
-        assert.equal(marshalBinaryHex, '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
-        assert.equal(e2.marshalBinary().toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400005061796c6f616448657265');
+        assert.strictEqual(marshalBinary.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(marshalBinaryHex, '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(e2.marshalBinary().toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400005061796c6f616448657265');
     });
 
     it('should compute hash', function () {
@@ -186,7 +186,7 @@ describe('Test Entry', function () {
 
         const hash = e.hash();
         assert.instanceOf(hash, Buffer);
-        assert.equal(hash.toString('hex'), '72177d733dcd0492066b79c5f3e417aef7f22909674f7dc351ca13b04742bb91');
+        assert.strictEqual(hash.toString('hex'), '72177d733dcd0492066b79c5f3e417aef7f22909674f7dc351ca13b04742bb91');
     });
 
     it('should compute EC cost', function () {
@@ -211,10 +211,10 @@ describe('Test Entry', function () {
             .content(Buffer.alloc(1024 - 2 - 3 + 1))
             .build();
 
-        assert.equal(e1.ecCost(), 1);
-        assert.equal(e4.ecCost(), 2);
-        assert.equal(e2.ecCost(), e1.ecCost());
-        assert.equal(e3.ecCost(), e1.ecCost() + 1);
+        assert.strictEqual(e1.ecCost(), 1);
+        assert.strictEqual(e4.ecCost(), 2);
+        assert.strictEqual(e2.ecCost(), e1.ecCost());
+        assert.strictEqual(e3.ecCost(), e1.ecCost() + 1);
     });
 
     it('should compose Entry commit', function () {
@@ -226,7 +226,7 @@ describe('Test Entry', function () {
 
         const commit = composeEntryCommit(e1, 'Es2d1a3uPx7o5uXHmsCnSEK2EKatPA56n8RUFmW9uRrpPRBuk5bZ');
         assert.instanceOf(commit, Buffer);
-        assert.equal(commit.toString('hex'),
+        assert.strictEqual(commit.toString('hex'),
             '000162a2e0a0c8fd461748e49aa77a6380c04059bd7e3040c9dbceca1828b37ddb737dd928909f015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b678790d79fc44d3c81fb701b2c3278b50b98eec215cd28be19bba5e1d96f7dc262ec8a87ae4cf9ea20eb43ef196052e761afb02a8f1a78df097c27c56a4a1d00f');
     });
 
@@ -250,7 +250,7 @@ describe('Test Entry', function () {
 
         const commit = composeEntryCommit(e1, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR', '78790d79fc44d3c81fb701b2c3278b50b98eec215cd28be19bba5e1d96f7dc262ec8a87ae4cf9ea20eb43ef196052e761afb02a8f1a78df097c27c56a4a1d00f');
         assert.instanceOf(commit, Buffer);
-        assert.equal(commit.toString('hex'),
+        assert.strictEqual(commit.toString('hex'),
             '000162a2e0a0c8fd461748e49aa77a6380c04059bd7e3040c9dbceca1828b37ddb737dd928909f015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b678790d79fc44d3c81fb701b2c3278b50b98eec215cd28be19bba5e1d96f7dc262ec8a87ae4cf9ea20eb43ef196052e761afb02a8f1a78df097c27c56a4a1d00f');
     });
 
@@ -282,7 +282,7 @@ describe('Test Entry', function () {
 
         const reveal = composeEntryReveal(e);
         assert.instanceOf(reveal, Buffer);
-        assert.equal(reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
     });
 
     it('should compose Entry commit and reveal', function () {
@@ -296,8 +296,8 @@ describe('Test Entry', function () {
         const composed = composeEntry(e, 'Es2d1a3uPx7o5uXHmsCnSEK2EKatPA56n8RUFmW9uRrpPRBuk5bZ');
         assert.instanceOf(composed.commit, Buffer);
         assert.instanceOf(composed.reveal, Buffer);
-        assert.equal(composed.commit.toString('hex'), '000162a2e0a0c8be705a58aea4230e99881f625e74cd085b6ef455b94ff144249b9a2f425e8f96015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b62a7642156b5cf73ecd0b54b803922c5365d58c372d33353995a1ef5b2ef889bdcd19a3101456379cc339642de1d623f6cade5af10addbcdd589d30e8bfe78702');
-        assert.equal(composed.reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(composed.commit.toString('hex'), '000162a2e0a0c8be705a58aea4230e99881f625e74cd085b6ef455b94ff144249b9a2f425e8f96015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b62a7642156b5cf73ecd0b54b803922c5365d58c372d33353995a1ef5b2ef889bdcd19a3101456379cc339642de1d623f6cade5af10addbcdd589d30e8bfe78702');
+        assert.strictEqual(composed.reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
     });
 
     it('should compose Entry commit and reveal with manually provided signature', function () {
@@ -311,8 +311,8 @@ describe('Test Entry', function () {
         const composed = composeEntry(e, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR', '2a7642156b5cf73ecd0b54b803922c5365d58c372d33353995a1ef5b2ef889bdcd19a3101456379cc339642de1d623f6cade5af10addbcdd589d30e8bfe78702');
         assert.instanceOf(composed.commit, Buffer);
         assert.instanceOf(composed.reveal, Buffer);
-        assert.equal(composed.commit.toString('hex'), '000162a2e0a0c8be705a58aea4230e99881f625e74cd085b6ef455b94ff144249b9a2f425e8f96015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b62a7642156b5cf73ecd0b54b803922c5365d58c372d33353995a1ef5b2ef889bdcd19a3101456379cc339642de1d623f6cade5af10addbcdd589d30e8bfe78702');
-        assert.equal(composed.reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
+        assert.strictEqual(composed.commit.toString('hex'), '000162a2e0a0c8be705a58aea4230e99881f625e74cd085b6ef455b94ff144249b9a2f425e8f96015d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b62a7642156b5cf73ecd0b54b803922c5365d58c372d33353995a1ef5b2ef889bdcd19a3101456379cc339642de1d623f6cade5af10addbcdd589d30e8bfe78702');
+        assert.strictEqual(composed.reveal.toString('hex'), '00954d5a49fd70d9b8bcdb35d252267829957f7ef7fa6c74f88419bdc5e82209f400060004746573745061796c6f616448657265');
     });
 
     it('should compute entry txId', function () {
@@ -326,7 +326,7 @@ describe('Test Entry', function () {
 
         const txId = computeEntryTxId(entry);
         assert.instanceOf(txId, Buffer);
-        assert.equal(txId.toString('hex'), 'd6e9aa572959910d4a0712c0fd23025f5f1bf4fb74467d2677e10048dc441883');
+        assert.strictEqual(txId.toString('hex'), 'd6e9aa572959910d4a0712c0fd23025f5f1bf4fb74467d2677e10048dc441883');
     });
 
     it('should convert to JS object', function () {
@@ -340,9 +340,9 @@ describe('Test Entry', function () {
 
         const obj = entry.toObject();
         assert.isObject(obj);
-        assert.equal(obj.chainId, entry.chainIdHex);
-        assert.equal(obj.content, entry.contentHex);
-        assert.equal(obj.timestamp, entry.timestamp);
+        assert.strictEqual(obj.chainId, entry.chainIdHex);
+        assert.strictEqual(obj.content, entry.contentHex);
+        assert.strictEqual(obj.timestamp, entry.timestamp);
         assert.deepEqual(Entry.builder(obj).build().hash(), entry.hash());
     });
 });

--- a/test/factom-cli.integration.spec.js
+++ b/test/factom-cli.integration.spec.js
@@ -194,17 +194,17 @@ describe('Test FactomCli', function () {
 
     it('should wait on commit ack', async function () {
         const status = await cli.waitOnCommitAck('bbd51be102e7ed19b825acd32d48f1f88033d5b14721f3003f925862b1baf135');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 
     it('should wait on reveal ack', async function () {
         const status = await cli.waitOnRevealAck('ac564d418ffaae59432d644d59fd11f6f0552a1211e9219e16037bc14296c630', '3b6432afd44edb3086571663a377ead1d08123e4210e5baf0c8f522369079791');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 
     it('should wait on Factoid transaction ack', async function () {
         const status = await cli.waitOnFactoidTransactionAck('09d23680a82f95faafd3562f6b76d83525bdd4575a74656809ced19fa45f72e6');
-        assert.equal(status, 'DBlockConfirmed');
+        assert.strictEqual(status, 'DBlockConfirmed');
     });
 
     it('should get heights', async function () {

--- a/test/factom-cli.unit.spec.js
+++ b/test/factom-cli.unit.spec.js
@@ -5,7 +5,7 @@ describe('Test FactomCli', function() {
 
     it('should set default factomd endpoint and port', function() {
         const cli = new FactomCli();
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:8088');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:8088');
     });
 
     it('should set factomd endpoint and port', function() {
@@ -13,21 +13,21 @@ describe('Test FactomCli', function() {
             host: '52.202.51.229',
             port: 1777
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
     });
 
     it('should set factomd endpoint and default port', function() {
         const cli = new FactomCli({
             host: '52.202.51.229'
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:8088');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:8088');
     });
 
     it('should set factomd port and default endpoint', function() {
         const cli = new FactomCli({
             port: 9888
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:9888');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:9888');
     });
 
     it('should set factomd endpoint and port', function() {
@@ -37,7 +37,7 @@ describe('Test FactomCli', function() {
                 port: 1777
             }
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
     });
 
     it('should set walletd endpoint and port', function() {
@@ -47,8 +47,8 @@ describe('Test FactomCli', function() {
                 port: 3111
             }
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:8088');
-        assert.equal(cli.walletd.httpCli.defaults.baseURL, 'http://52.202.51.229:3111');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://localhost:8088');
+        assert.strictEqual(cli.walletd.httpCli.defaults.baseURL, 'http://52.202.51.229:3111');
     });
 
     it('should set both factomd and walletd endpoint and port', function() {
@@ -62,8 +62,8 @@ describe('Test FactomCli', function() {
                 port: 5656
             }
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
-        assert.equal(cli.walletd.httpCli.defaults.baseURL, 'http://88.202.51.229:5656');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'http://52.202.51.229:1777');
+        assert.strictEqual(cli.walletd.httpCli.defaults.baseURL, 'http://88.202.51.229:5656');
     });
 
     it('should use https', function() {
@@ -74,7 +74,7 @@ describe('Test FactomCli', function() {
                 rejectUnauthorized: false
             }
         });
-        assert.equal(cli.factomd.httpCli.defaults.baseURL, 'https://52.202.51.229:8088');
+        assert.strictEqual(cli.factomd.httpCli.defaults.baseURL, 'https://52.202.51.229:8088');
     });
 
 });

--- a/test/get.integration.spec.js
+++ b/test/get.integration.spec.js
@@ -17,10 +17,10 @@ describe('Get information from Factom blockchain', function () {
 
         assert.isUndefined(entry.timestamp);
         assert.isUndefined(entry.blockContext);
-        assert.equal(entry.chainId.toString('hex'), 'e36c51b43d979f10792ab14d8b4e87f2870962e0bdb4d2c3cc5aba6c3fb4d7d2');
+        assert.strictEqual(entry.chainId.toString('hex'), 'e36c51b43d979f10792ab14d8b4e87f2870962e0bdb4d2c3cc5aba6c3fb4d7d2');
         assert.lengthOf(entry.extIds, 3);
-        assert.equal(entry.extIds[0].toString(), 'PrimeNumbers.txt');
-        assert.equal(entry.content.toString(), '53746, 662369, 12\r\n');
+        assert.strictEqual(entry.extIds[0].toString(), 'PrimeNumbers.txt');
+        assert.strictEqual(entry.content.toString(), '53746, 662369, 12\r\n');
     });
 
     it('should get first entry', async function () {
@@ -28,8 +28,8 @@ describe('Get information from Factom blockchain', function () {
 
         const entry = await get.getFirstEntry(factomd, 'f48d2160c5d8178720d8c83b89a62599ab6a8b9dbec9fbece5229f787d1e8b44');
 
-        assert.equal(entry.hashHex(), 'ed909db55c0abc861a5a164d1dac7be70ffd117e6f1545491e6a253764f52bb2');
-        assert.equal(entry.extIds[0].toString(), 'factom-testnet-pioneers');
+        assert.strictEqual(entry.hashHex(), 'ed909db55c0abc861a5a164d1dac7be70ffd117e6f1545491e6a253764f52bb2');
+        assert.strictEqual(entry.extIds[0].toString(), 'factom-testnet-pioneers');
         // Entries retrieved via getFirstEntry should have a Block context
         assert.isNumber(entry.timestamp);
         assert.isObject(entry.blockContext);
@@ -53,14 +53,14 @@ describe('Get information from Factom blockchain', function () {
     });
 
     function assertEntryWithBlockContext(entry) {
-        assert.equal(entry.hashHex(), 'caf017da212bb68ffee2ba645e1488e5834863743d50972dd3009eab2b93eb42');
-        assert.equal(entry.timestamp, 1518286500000);
+        assert.strictEqual(entry.hashHex(), 'caf017da212bb68ffee2ba645e1488e5834863743d50972dd3009eab2b93eb42');
+        assert.strictEqual(entry.timestamp, 1518286500000);
         assert.isObject(entry.blockContext);
-        assert.equal(entry.blockContext.entryTimestamp, 1518286500);
-        assert.equal(entry.blockContext.directoryBlockHeight, 7042);
-        assert.equal(entry.blockContext.entryBlockTimestamp, 1518286440);
-        assert.equal(entry.blockContext.entryBlockSequenceNumber, 1);
-        assert.equal(entry.blockContext.entryBlockKeyMR, 'a13ac9df4153903f5a07093effe6434bdeb35fea0ff4bd402f323e486bea6ea4');
+        assert.strictEqual(entry.blockContext.entryTimestamp, 1518286500);
+        assert.strictEqual(entry.blockContext.directoryBlockHeight, 7042);
+        assert.strictEqual(entry.blockContext.entryBlockTimestamp, 1518286440);
+        assert.strictEqual(entry.blockContext.entryBlockSequenceNumber, 1);
+        assert.strictEqual(entry.blockContext.entryBlockKeyMR, 'a13ac9df4153903f5a07093effe6434bdeb35fea0ff4bd402f323e486bea6ea4');
     }
 
     it('should get balance', async function () {
@@ -83,25 +83,25 @@ describe('Get information from Factom blockchain', function () {
         const transaction = await get.getTransaction(factomd, '63fe4275064427f11e0dcfc3ff2d56adf88ba12c2646bc0d03d03a02ff7d2727');
 
         assert.instanceOf(transaction, Transaction);
-        assert.equal(transaction.id, '63fe4275064427f11e0dcfc3ff2d56adf88ba12c2646bc0d03d03a02ff7d2727');
-        assert.equal(transaction.timestamp, 1525490539106);
-        assert.equal(transaction.totalInputs, 400012000);
-        assert.equal(transaction.totalFactoidOutputs, 400000000);
-        assert.equal(transaction.totalEntryCreditOutputs, 0);
-        assert.equal(transaction.feesPaid, 12000);
+        assert.strictEqual(transaction.id, '63fe4275064427f11e0dcfc3ff2d56adf88ba12c2646bc0d03d03a02ff7d2727');
+        assert.strictEqual(transaction.timestamp, 1525490539106);
+        assert.strictEqual(transaction.totalInputs, 400012000);
+        assert.strictEqual(transaction.totalFactoidOutputs, 400000000);
+        assert.strictEqual(transaction.totalEntryCreditOutputs, 0);
+        assert.strictEqual(transaction.feesPaid, 12000);
         assert.lengthOf(transaction.inputs, 1);
         assert.lengthOf(transaction.factoidOutputs, 1);
         assert.lengthOf(transaction.entryCreditOutputs, 0);
-        assert.equal(transaction.rcds[0].toString('hex'), '011bcb4c8a771c2869ddf554655414e56bdf360663f33960039a9aa43ac5820306')
-        assert.equal(transaction.signatures[0].toString('hex'), '8a3f90a2b47efda21b801d2dc7f8dbbbfe9c0a65cb37aea4a998632ab7578aa965c8b5893f069030c4411a76dddc357270c0d835a31ea4fd34290a925d4c5501')
-        assert.equal(transaction.inputs[0].address, 'FA3syRxpYEvFFvoN4ZfNRJVQdumLpTK4CMmMUFmKGeqyTNgsg4uH');
-        assert.equal(transaction.inputs[0].amount, 400012000);
-        assert.equal(transaction.factoidOutputs[0].address, 'FA3cnxxcRxm6RQs2hpExdEPo9utyeBZecWKeKa1pFDCrRoQh9aVw');
-        assert.equal(transaction.factoidOutputs[0].amount, 400000000);
+        assert.strictEqual(transaction.rcds[0].toString('hex'), '011bcb4c8a771c2869ddf554655414e56bdf360663f33960039a9aa43ac5820306');
+        assert.strictEqual(transaction.signatures[0].toString('hex'), '8a3f90a2b47efda21b801d2dc7f8dbbbfe9c0a65cb37aea4a998632ab7578aa965c8b5893f069030c4411a76dddc357270c0d835a31ea4fd34290a925d4c5501');
+        assert.strictEqual(transaction.inputs[0].address, 'FA3syRxpYEvFFvoN4ZfNRJVQdumLpTK4CMmMUFmKGeqyTNgsg4uH');
+        assert.strictEqual(transaction.inputs[0].amount, 400012000);
+        assert.strictEqual(transaction.factoidOutputs[0].address, 'FA3cnxxcRxm6RQs2hpExdEPo9utyeBZecWKeKa1pFDCrRoQh9aVw');
+        assert.strictEqual(transaction.factoidOutputs[0].amount, 400000000);
         assert.isObject(transaction.blockContext);
-        assert.equal(transaction.blockContext.directoryBlockHeight, 27618);
-        assert.equal(transaction.blockContext.directoryBlockKeyMR, 'bb971007b95ac7474a573276d010cb0e7cf1d04bc93765c90e757f2555cc90e7');
-        assert.equal(transaction.blockContext.factoidBlockKeyMR, 'bb622dc852a278ede8fbfd0144ae49d6576e621a1267932dfd198c2cea73b403');
+        assert.strictEqual(transaction.blockContext.directoryBlockHeight, 27618);
+        assert.strictEqual(transaction.blockContext.directoryBlockKeyMR, 'bb971007b95ac7474a573276d010cb0e7cf1d04bc93765c90e757f2555cc90e7');
+        assert.strictEqual(transaction.blockContext.factoidBlockKeyMR, 'bb622dc852a278ede8fbfd0144ae49d6576e621a1267932dfd198c2cea73b403');
     });
 
     it('should reject incorrect transaction id', async function () {
@@ -132,40 +132,40 @@ describe('Get information from Factom blockchain', function () {
         const transaction = await get.getTransaction(factomd, '4099f0fe5ba3ccdccb0ee5e45f9d3d513bb9994c781acb54b49ae15d85f1e9d9');
 
         assert.instanceOf(transaction, Transaction);
-        assert.equal(transaction.id, '4099f0fe5ba3ccdccb0ee5e45f9d3d513bb9994c781acb54b49ae15d85f1e9d9');
-        assert.equal(transaction.totalInputs, 0);
-        assert.equal(transaction.totalFactoidOutputs, 640000000);
-        assert.equal(transaction.totalEntryCreditOutputs, 0);
-        assert.equal(transaction.feesPaid, 0);
+        assert.strictEqual(transaction.id, '4099f0fe5ba3ccdccb0ee5e45f9d3d513bb9994c781acb54b49ae15d85f1e9d9');
+        assert.strictEqual(transaction.totalInputs, 0);
+        assert.strictEqual(transaction.totalFactoidOutputs, 640000000);
+        assert.strictEqual(transaction.totalEntryCreditOutputs, 0);
+        assert.strictEqual(transaction.feesPaid, 0);
         assert.lengthOf(transaction.inputs, 0);
         assert.lengthOf(transaction.factoidOutputs, 2);
         assert.lengthOf(transaction.entryCreditOutputs, 0);
-        assert.equal(transaction.factoidOutputs[0].address, 'FA36vN5aQU2DAofpisurQhDSvx73MVatA53kSstTgcts8h2T9cvx');
-        assert.equal(transaction.factoidOutputs[0].amount, 320000000);
+        assert.strictEqual(transaction.factoidOutputs[0].address, 'FA36vN5aQU2DAofpisurQhDSvx73MVatA53kSstTgcts8h2T9cvx');
+        assert.strictEqual(transaction.factoidOutputs[0].amount, 320000000);
     });
 
     it('should get heights', async function () {
         const heights = await get.getHeights(factomd);
 
         assert.isNumber(heights.directoryBlockHeight);
-        assert.notEqual(heights.directoryBlockHeight, 0);
+        assert.notStrictEqual(heights.directoryBlockHeight, 0);
         assert.isNumber(heights.leaderHeight);
-        assert.notEqual(heights.leaderHeight, 0);
+        assert.notStrictEqual(heights.leaderHeight, 0);
         assert.isNumber(heights.entryBlockHeight);
-        assert.notEqual(heights.entryBlockHeight, 0);
+        assert.notStrictEqual(heights.entryBlockHeight, 0);
         assert.isNumber(heights.entryHeight);
-        assert.notEqual(heights.entryHeight, 0);
+        assert.notStrictEqual(heights.entryHeight, 0);
     });
 
     function assertDirectoryBlock(db) {
         assert.instanceOf(db, DirectoryBlock);
-        assert.equal(db.keyMR, 'f55a19d9562843b642f1a20b34fcbb71e70f438c4d98d223fc2228ca2dd0c54a');
-        assert.equal(db.height, 21537);
-        assert.equal(db.previousBlockKeyMR, 'b37bf4eee21547773c74fa099c643588835e4ada9a4a8c22f0dd171e22710bf5');
-        assert.equal(db.timestamp, 1521348840);
-        assert.equal(db.adminBlockRef, '643f3a4f0a5fd7a44374affe47fd052a845a078482319ad6540aa7f1f714bb9e');
-        assert.equal(db.entryCreditBlockRef, 'f4540b4170666a47b1287c4d0843b91d5a0ebcf8433c40b674d017f146503256');
-        assert.equal(db.factoidBlockRef, 'baf6e92932f4ba0f81baacf7b7d7726d6f7f3a4da0c43bfdaf846a843c8f2301');
+        assert.strictEqual(db.keyMR, 'f55a19d9562843b642f1a20b34fcbb71e70f438c4d98d223fc2228ca2dd0c54a');
+        assert.strictEqual(db.height, 21537);
+        assert.strictEqual(db.previousBlockKeyMR, 'b37bf4eee21547773c74fa099c643588835e4ada9a4a8c22f0dd171e22710bf5');
+        assert.strictEqual(db.timestamp, 1521348840);
+        assert.strictEqual(db.adminBlockRef, '643f3a4f0a5fd7a44374affe47fd052a845a078482319ad6540aa7f1f714bb9e');
+        assert.strictEqual(db.entryCreditBlockRef, 'f4540b4170666a47b1287c4d0843b91d5a0ebcf8433c40b674d017f146503256');
+        assert.strictEqual(db.factoidBlockRef, 'baf6e92932f4ba0f81baacf7b7d7726d6f7f3a4da0c43bfdaf846a843c8f2301');
         assert.lengthOf(db.entryBlockRefs, 23);
     }
 
@@ -178,9 +178,9 @@ describe('Get information from Factom blockchain', function () {
         const byHeight = await get.getDirectoryBlock(factomd, 21537);
         assertDirectoryBlock(byHeight);
 
-        assert.equal(byHeight.fullHash, 'd435f58a88eb9967e8be864af7015a9a01a50f716181a8bee5e86593bc4a0f8d');
-        assert.equal(byHeight.previousFullHash, 'f0dc9915ff0db78648a8366a1768332c74d28913f3ae4699d4fab7dc6d935b31');
-        assert.equal(byHeight.bodyKeyMR, '6243865ba04b031423a2d6b48335c571b48499e71b7630f233e885f832bfdd30');
+        assert.strictEqual(byHeight.fullHash, 'd435f58a88eb9967e8be864af7015a9a01a50f716181a8bee5e86593bc4a0f8d');
+        assert.strictEqual(byHeight.previousFullHash, 'f0dc9915ff0db78648a8366a1768332c74d28913f3ae4699d4fab7dc6d935b31');
+        assert.strictEqual(byHeight.bodyKeyMR, '6243865ba04b031423a2d6b48335c571b48499e71b7630f233e885f832bfdd30');
     });
 
     it('should reject negative block height for getDirectoryBlock', async function () {
@@ -205,15 +205,15 @@ describe('Get information from Factom blockchain', function () {
 
     function assertEntryCreditBlock(ecb) {
         assert.instanceOf(ecb, EntryCreditBlock);
-        assert.equal(ecb.fullHash, '4cf58af96b2dcdf416217cbdb195d67f1a511a8ab95a8e37aebeb8e643cb8f3c');
-        assert.equal(ecb.headerHash, '96ad20412e7799e80f3979c425bfa5641282563371cd40049492701f9c09e338');
-        assert.equal(ecb.bodyHash, 'd9b5f08c5002bfa70c7b98a61c02eddaa3544299eb498840641b3a9e6d771bda');
-        assert.equal(ecb.previousFullHash, 'ae8ab99b07b9d367a36f8a54fe0020532fbb20c71f65dfa2dacdee5bceb1b332');
-        assert.equal(ecb.previousHeaderHash, '48ff34b7bf9807e59e07c2c3d9a96c2442fcde8446952b258223b65b4d75190b');
-        assert.equal(ecb.directoryBlockHeight, 17997);
-        assert.equal(ecb.headerExpansionArea, '');
-        assert.equal(ecb.bodySize, 11939);
-        assert.equal(ecb.objectCount, 97);
+        assert.strictEqual(ecb.fullHash, '4cf58af96b2dcdf416217cbdb195d67f1a511a8ab95a8e37aebeb8e643cb8f3c');
+        assert.strictEqual(ecb.headerHash, '96ad20412e7799e80f3979c425bfa5641282563371cd40049492701f9c09e338');
+        assert.strictEqual(ecb.bodyHash, 'd9b5f08c5002bfa70c7b98a61c02eddaa3544299eb498840641b3a9e6d771bda');
+        assert.strictEqual(ecb.previousFullHash, 'ae8ab99b07b9d367a36f8a54fe0020532fbb20c71f65dfa2dacdee5bceb1b332');
+        assert.strictEqual(ecb.previousHeaderHash, '48ff34b7bf9807e59e07c2c3d9a96c2442fcde8446952b258223b65b4d75190b');
+        assert.strictEqual(ecb.directoryBlockHeight, 17997);
+        assert.strictEqual(ecb.headerExpansionArea, '');
+        assert.strictEqual(ecb.bodySize, 11939);
+        assert.strictEqual(ecb.objectCount, 97);
         assert.lengthOf(ecb.commits, 87);
         assert.lengthOf(ecb.minuteIndexes, 11);
     }
@@ -251,22 +251,22 @@ describe('Get information from Factom blockchain', function () {
 
     function assertFactoidBlock(fb) {
         assert.instanceOf(fb, FactoidBlock);
-        assert.equal(fb.keyMR, '4b2572326cc04f4bff215800bc3f48b2e64f2002f0c2b592e09b003ea3f36bdd');
-        assert.equal(fb.previousBlockKeyMR, 'a7074a34b37954944224a3cd13a19f690f5b0d12d3373b2f54904329e02c56ec');
-        assert.equal(fb.bodyMR, 'ca7641b49bb5cc2d00145b28a5634305490fb0caa96c6a838959910803e8008f');
-        assert.equal(fb.entryCreditRate, 1000);
-        assert.equal(fb.directoryBlockHeight, 55010);
-        assert.equal(fb.ledgerKeyMR, '72cc3a6d43c72532e0670941e1bb35074e8ab1d55715a2e0687b5fc1540e8fef');
-        assert.equal(fb.previousLedgerKeyMR, '977cd8f7a847770756d040711690aff7b3cbd7f54665152ec72b7de411cf4de9');
+        assert.strictEqual(fb.keyMR, '4b2572326cc04f4bff215800bc3f48b2e64f2002f0c2b592e09b003ea3f36bdd');
+        assert.strictEqual(fb.previousBlockKeyMR, 'a7074a34b37954944224a3cd13a19f690f5b0d12d3373b2f54904329e02c56ec');
+        assert.strictEqual(fb.bodyMR, 'ca7641b49bb5cc2d00145b28a5634305490fb0caa96c6a838959910803e8008f');
+        assert.strictEqual(fb.entryCreditRate, 1000);
+        assert.strictEqual(fb.directoryBlockHeight, 55010);
+        assert.strictEqual(fb.ledgerKeyMR, '72cc3a6d43c72532e0670941e1bb35074e8ab1d55715a2e0687b5fc1540e8fef');
+        assert.strictEqual(fb.previousLedgerKeyMR, '977cd8f7a847770756d040711690aff7b3cbd7f54665152ec72b7de411cf4de9');
         assert.lengthOf(fb.transactions, 1);
 
         const coinbaseTx = fb.getCoinbaseTransaction();
         assert.instanceOf(coinbaseTx, Transaction);
-        assert.equal(coinbaseTx.totalInputs, 0);
-        assert.equal(coinbaseTx.totalFactoidOutputs, 6398208000);
+        assert.strictEqual(coinbaseTx.totalInputs, 0);
+        assert.strictEqual(coinbaseTx.totalFactoidOutputs, 6398208000);
         assert.isObject(coinbaseTx.blockContext);
-        assert.equal(coinbaseTx.blockContext.factoidBlockKeyMR, '4b2572326cc04f4bff215800bc3f48b2e64f2002f0c2b592e09b003ea3f36bdd');
-        assert.equal(coinbaseTx.blockContext.directoryBlockHeight, 55010);
+        assert.strictEqual(coinbaseTx.blockContext.factoidBlockKeyMR, '4b2572326cc04f4bff215800bc3f48b2e64f2002f0c2b592e09b003ea3f36bdd');
+        assert.strictEqual(coinbaseTx.blockContext.directoryBlockHeight, 55010);
     }
 
     it('should get Factoid Block', async function () {
@@ -305,12 +305,12 @@ describe('Get information from Factom blockchain', function () {
         const eb = await get.getEntryBlock(factomd, '3944669331eea620f7f3ec67864a03a646a104f17e36aec3e0f5bdf638f16883');
 
         assert.instanceOf(eb, EntryBlock);
-        assert.equal(eb.keyMR, '3944669331eea620f7f3ec67864a03a646a104f17e36aec3e0f5bdf638f16883');
-        assert.equal(eb.previousBlockKeyMR, '1af04b34c3a0113d14aa0fcbb8c609864fa2e8f24dd04e9814aa7e5a40376a70');
-        assert.equal(eb.timestamp, 1521429840);
-        assert.equal(eb.directoryBlockHeight, 21672);
-        assert.equal(eb.chainId, '3f69bdf3b4769ff53407580b882ee01e0c365f6deffba4ed8d4651b24e65389a');
-        assert.equal(eb.sequenceNumber, 1168);
+        assert.strictEqual(eb.keyMR, '3944669331eea620f7f3ec67864a03a646a104f17e36aec3e0f5bdf638f16883');
+        assert.strictEqual(eb.previousBlockKeyMR, '1af04b34c3a0113d14aa0fcbb8c609864fa2e8f24dd04e9814aa7e5a40376a70');
+        assert.strictEqual(eb.timestamp, 1521429840);
+        assert.strictEqual(eb.directoryBlockHeight, 21672);
+        assert.strictEqual(eb.chainId, '3f69bdf3b4769ff53407580b882ee01e0c365f6deffba4ed8d4651b24e65389a');
+        assert.strictEqual(eb.sequenceNumber, 1168);
         assert.lengthOf(eb.entryRefs, 50);
     });
 
@@ -327,13 +327,13 @@ describe('Get information from Factom blockchain', function () {
 
     function assertAdminBlock(ab) {
         assert.instanceOf(ab, AdminBlock);
-        assert.equal(ab.backReferenceHash, 'd6d21564d9b1b1e55fa308890821ed4151ded40a33cb3cf8edaecf2b63e32236');
-        assert.equal(ab.lookupHash, 'c98beb0b3cbfbb090acdd238ca17725119eb43f1df5ef117ffbdc59f050508e6');
-        assert.equal(ab.previousBackReferenceHash, 'a24beb7bcd0d47857fcd0b570ea3c16704daf3377d9b9588c6305e9271539eea');
-        assert.equal(ab.directoryBlockHeight, 21662);
-        assert.equal(ab.headerExpansionArea, '');
-        assert.equal(ab.headerExpansionSize, 0);
-        assert.equal(ab.bodySize, 387);
+        assert.strictEqual(ab.backReferenceHash, 'd6d21564d9b1b1e55fa308890821ed4151ded40a33cb3cf8edaecf2b63e32236');
+        assert.strictEqual(ab.lookupHash, 'c98beb0b3cbfbb090acdd238ca17725119eb43f1df5ef117ffbdc59f050508e6');
+        assert.strictEqual(ab.previousBackReferenceHash, 'a24beb7bcd0d47857fcd0b570ea3c16704daf3377d9b9588c6305e9271539eea');
+        assert.strictEqual(ab.directoryBlockHeight, 21662);
+        assert.strictEqual(ab.headerExpansionArea, '');
+        assert.strictEqual(ab.headerExpansionSize, 0);
+        assert.strictEqual(ab.bodySize, 387);
         assert.lengthOf(ab.entries, 3);
     }
 
@@ -392,7 +392,7 @@ describe('Get information from Factom blockchain', function () {
             assert.instanceOf(entry, Entry);
             counter++;
         });
-        assert.equal(counter, 5);
+        assert.strictEqual(counter, 5);
     });
 
     it('should not rewind chain ', async function () {
@@ -416,8 +416,8 @@ describe('Get information from Factom blockchain', function () {
             }
         });
 
-        assert.equal(counter, 3);
-        assert.equal(found.hash().toString('hex'), '0ef649d17f4f1e961a0e5d0d7f294ae151253d72564958763821aee1dc6ac37f');
+        assert.strictEqual(counter, 3);
+        assert.strictEqual(found.hash().toString('hex'), '0ef649d17f4f1e961a0e5d0d7f294ae151253d72564958763821aee1dc6ac37f');
     });
 
     it('should validate rewind chain predicate function', async function () {

--- a/test/send.integration.spec.js
+++ b/test/send.integration.spec.js
@@ -85,7 +85,6 @@ describe('Send transactions', function () {
 
         const transaction = await send.createEntryCreditPurchaseTransaction(factomd, PAYING_FCT_ADDRESS, RECEIVING_EC_ADDRESS, 1);
         await send.sendTransaction(factomd, transaction);
-
     });
 
 
@@ -174,7 +173,6 @@ describe('Send transactions', function () {
             .build();
 
         await send.sendTransaction(factomd, transaction, { force: true });
-
     });
 
 });

--- a/test/transaction.unit.spec.js
+++ b/test/transaction.unit.spec.js
@@ -20,9 +20,9 @@ describe('Test Factoid transaction creation', function () {
         assert.lengthOf(tx.signatures, 2);
         assert.isTrue(tx.isSigned());
         assert.isTrue(tx.validateFees(1000));
-        assert.equal(tx.computeEcRequiredFees(), 23);
-        assert.equal(tx.computeRequiredFees(1000), 23000);
-        assert.equal(tx.marshalBinary().toString('hex'), '0201624bfe45a602010186d6bf00ada661a0c8f36a31ee89054001f2b283f05fbcbb40076bc7a8a7e2fc6ec05cb6859fb1407e5a8f7716e9bed9db6289dfe9b9b2d8393ebbc68b9b0546df8e1145dd964c3382b19640d954883481f3aa501f3f5d4f9e796bafe8aa01bfe89780771e733d6396f8fb9b82ee9b005d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b601a4a8befef8404ab4d68a0e65ed121190ffb60ad5c99f9c7d252fb99748f8258f8154d661fbc2a95a4451ee2a00d4f613f066741ffcd52c74466c349ae779f967431bcaa3047982c2172cab74386ee49e5986c053a1b7c1be4b39856bc370eb020137dc52975d81dc28c827fedeae5e0527027e766064179382854169a5aaf5256f624da47b578221aee786d83f8aff3d37aeb585b421f7a243c8915a0779c8a18aa30283c0286aea07ecebdeb4c177dfd190f2398eebe63b96d939233a026e2503');
+        assert.strictEqual(tx.computeEcRequiredFees(), 23);
+        assert.strictEqual(tx.computeRequiredFees(1000), 23000);
+        assert.strictEqual(tx.marshalBinary().toString('hex'), '0201624bfe45a602010186d6bf00ada661a0c8f36a31ee89054001f2b283f05fbcbb40076bc7a8a7e2fc6ec05cb6859fb1407e5a8f7716e9bed9db6289dfe9b9b2d8393ebbc68b9b0546df8e1145dd964c3382b19640d954883481f3aa501f3f5d4f9e796bafe8aa01bfe89780771e733d6396f8fb9b82ee9b005d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b601a4a8befef8404ab4d68a0e65ed121190ffb60ad5c99f9c7d252fb99748f8258f8154d661fbc2a95a4451ee2a00d4f613f066741ffcd52c74466c349ae779f967431bcaa3047982c2172cab74386ee49e5986c053a1b7c1be4b39856bc370eb020137dc52975d81dc28c827fedeae5e0527027e766064179382854169a5aaf5256f624da47b578221aee786d83f8aff3d37aeb585b421f7a243c8915a0779c8a18aa30283c0286aea07ecebdeb4c177dfd190f2398eebe63b96d939233a026e2503');
 
         for (let i = 0; i < tx.signatures.length; ++i) {
             assert.isTrue(sign.detached.verify(tx.marshalBinarySig, tx.signatures[i], Buffer.from(tx.rcds[i], 1).slice(1)));
@@ -44,31 +44,31 @@ describe('Test Factoid transaction creation', function () {
         assert.lengthOf(tx.rcds, 0);
         assert.lengthOf(tx.signatures, 0);
         assert.isFalse(tx.isSigned());
-        assert.equal(tx.computeEcRequiredFees({ rcdType: 1 }), 23);
-        assert.equal(tx.computeRequiredFees(1000, { rcdType: 1 }), 23000);
+        assert.strictEqual(tx.computeEcRequiredFees({ rcdType: 1 }), 23);
+        assert.strictEqual(tx.computeRequiredFees(1000, { rcdType: 1 }), 23000);
     });
 
     function assertTransaction(tx) {
-        assert.equal(tx.timestamp, 1521693377958);
+        assert.strictEqual(tx.timestamp, 1521693377958);
         assert.lengthOf(tx.inputs, 2);
         assert.lengthOf(tx.factoidOutputs, 1);
         assert.lengthOf(tx.entryCreditOutputs, 1);
 
-        assert.equal(tx.totalInputs, 25000000);
-        assert.equal(tx.totalFactoidOutputs, 5000000);
-        assert.equal(tx.totalEntryCreditOutputs, 6000000);
-        assert.equal(tx.feesPaid, 14000000);
+        assert.strictEqual(tx.totalInputs, 25000000);
+        assert.strictEqual(tx.totalFactoidOutputs, 5000000);
+        assert.strictEqual(tx.totalEntryCreditOutputs, 6000000);
+        assert.strictEqual(tx.feesPaid, 14000000);
 
-        assert.equal(tx.marshalBinarySig.toString('hex'), '0201624bfe45a602010186d6bf00ada661a0c8f36a31ee89054001f2b283f05fbcbb40076bc7a8a7e2fc6ec05cb6859fb1407e5a8f7716e9bed9db6289dfe9b9b2d8393ebbc68b9b0546df8e1145dd964c3382b19640d954883481f3aa501f3f5d4f9e796bafe8aa01bfe89780771e733d6396f8fb9b82ee9b005d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6');
+        assert.strictEqual(tx.marshalBinarySig.toString('hex'), '0201624bfe45a602010186d6bf00ada661a0c8f36a31ee89054001f2b283f05fbcbb40076bc7a8a7e2fc6ec05cb6859fb1407e5a8f7716e9bed9db6289dfe9b9b2d8393ebbc68b9b0546df8e1145dd964c3382b19640d954883481f3aa501f3f5d4f9e796bafe8aa01bfe89780771e733d6396f8fb9b82ee9b005d54e4b02234a10b542573645f7ba55650f25eb931985cddcf451df77594b5b6');
 
-        assert.equal(tx.inputs[0].address, 'FA3HZDE4MdXAthauFoA3aKYpx33U4fT2kAABmfwk7NBqyLT2zed5');
-        assert.equal(tx.inputs[0].amount, 14000000);
-        assert.equal(tx.inputs[1].address, 'FA2vj6RNSijgB7Zufg2po9XVJYmQm6bLYo721Yv5LEuMe8ijH1yq');
-        assert.equal(tx.inputs[1].amount, 11000000);
-        assert.equal(tx.factoidOutputs[0].address, 'FA3cnxxcRxm6RQs2hpExdEPo9utyeBZecWKeKa1pFDCrRoQh9aVw');
-        assert.equal(tx.factoidOutputs[0].amount, 5000000);
-        assert.equal(tx.entryCreditOutputs[0].address, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR');
-        assert.equal(tx.entryCreditOutputs[0].amount, 6000000);
+        assert.strictEqual(tx.inputs[0].address, 'FA3HZDE4MdXAthauFoA3aKYpx33U4fT2kAABmfwk7NBqyLT2zed5');
+        assert.strictEqual(tx.inputs[0].amount, 14000000);
+        assert.strictEqual(tx.inputs[1].address, 'FA2vj6RNSijgB7Zufg2po9XVJYmQm6bLYo721Yv5LEuMe8ijH1yq');
+        assert.strictEqual(tx.inputs[1].amount, 11000000);
+        assert.strictEqual(tx.factoidOutputs[0].address, 'FA3cnxxcRxm6RQs2hpExdEPo9utyeBZecWKeKa1pFDCrRoQh9aVw');
+        assert.strictEqual(tx.factoidOutputs[0].amount, 5000000);
+        assert.strictEqual(tx.entryCreditOutputs[0].address, 'EC2UFobcsWom2NvyNDN67Q8eTdpCQvwYe327ZeGTLXbYaZ56e9QR');
+        assert.strictEqual(tx.entryCreditOutputs[0].amount, 6000000);
     }
 
     it('should compute fees of generic unsigned transaction', async function () {
@@ -83,8 +83,8 @@ describe('Test Factoid transaction creation', function () {
             .build();
 
         assert.isFalse(tx.isSigned());
-        assert.equal(tx.computeEcRequiredFees({ rcdSignatureLength: 2 * (33 + 64), numberOfSignatures: 2 }), 23);
-        assert.equal(tx.computeRequiredFees(1000, { rcdSignatureLength: 2 * (33 + 64), numberOfSignatures: 2 }), 23000);
+        assert.strictEqual(tx.computeEcRequiredFees({ rcdSignatureLength: 2 * (33 + 64), numberOfSignatures: 2 }), 23);
+        assert.strictEqual(tx.computeRequiredFees(1000, { rcdSignatureLength: 2 * (33 + 64), numberOfSignatures: 2 }), 23000);
     });
 
     it('should copy transaction without signature', async function () {
@@ -100,15 +100,15 @@ describe('Test Factoid transaction creation', function () {
         const unsignedCopy = Transaction.builder(tx).build();
 
         assert.isFalse(unsignedCopy.isSigned());
-        assert.equal(unsignedCopy.timestamp, timestamp);
+        assert.strictEqual(unsignedCopy.timestamp, timestamp);
         assert.lengthOf(unsignedCopy.inputs, 1);
         assert.lengthOf(unsignedCopy.factoidOutputs, 1);
         assert.lengthOf(unsignedCopy.entryCreditOutputs, 1);
         assert.lengthOf(unsignedCopy.rcds, 0);
         assert.lengthOf(unsignedCopy.signatures, 0);
-        assert.equal(unsignedCopy.totalInputs, 14000000);
-        assert.equal(unsignedCopy.totalFactoidOutputs, 5000000);
-        assert.equal(unsignedCopy.totalEntryCreditOutputs, 6000000);
+        assert.strictEqual(unsignedCopy.totalInputs, 14000000);
+        assert.strictEqual(unsignedCopy.totalFactoidOutputs, 5000000);
+        assert.strictEqual(unsignedCopy.totalEntryCreditOutputs, 6000000);
     });
 
     it('should manually signed transaction', async function () {
@@ -125,8 +125,7 @@ describe('Test Factoid transaction creation', function () {
             .rcdSignature(tx.rcds[0], tx.signatures[0])
             .build();
 
-        assert.deepEqual(manuallySignedCopy.marshalBinary(), tx.marshalBinary());
-
+        assert.deepStrictEqual(manuallySignedCopy.marshalBinary(), tx.marshalBinary());
     });
 
     it('should reject transaction with outputs greater than inputs (and not coinbase)', async function () {

--- a/test/wallet.spec.js
+++ b/test/wallet.spec.js
@@ -21,10 +21,10 @@ describe('Test wallet', function() {
 
         mock.expects('call').never();
 
-        assert.equal(await wallet.getPrivateAddress(walletd, 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym'), 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym');
+        assert.strictEqual(await wallet.getPrivateAddress(walletd, 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym'), 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym');
         mock.verify();
 
-        assert.equal(await wallet.getPrivateAddress(walletd, 'Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X'), 'Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X');
+        assert.strictEqual(await wallet.getPrivateAddress(walletd, 'Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X'), 'Fs2w6VL6cwBqt6SpUyPLvdo9TK834gCr52Y225z8C5aHPAFav36X');
         mock.verify();
     });
 
@@ -37,7 +37,7 @@ describe('Test wallet', function() {
             .withArgs('address', { address: 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD' })
             .returns(Promise.resolve({ secret: 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym' }));
 
-        assert.equal(await wallet.getPrivateAddress(walletd, 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD'), 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym');
+        assert.strictEqual(await wallet.getPrivateAddress(walletd, 'EC2vXWYkAPduo3oo2tPuzA44Tm7W6Cj7SeBr3fBnzswbG5rrkSTD'), 'Es32PjobTxPTd73dohEFRegMFRLv3X5WZ4FXEwNN8kE2pMDfeMym');
         mock.verify();
     });
 });


### PR DESCRIPTION
Use `assert.strictEquals()` and `assert.strictNotEquals()` in tests. Standardize line spacing for some tests. 

Add IntelliJ IDEA (Webstorm) files to .gitignore.